### PR TITLE
Fix Rubocop offense

### DIFF
--- a/lib/facebook_ads.rb
+++ b/lib/facebook_ads.rb
@@ -13,7 +13,7 @@ module FacebookAds
     end
 
     def config
-      @config ||= OpenStruct.new()
+      @config ||= OpenStruct.new
     end
   end
 end


### PR DESCRIPTION
Offense: "Do not use parentheses for method calls with no arguments"
